### PR TITLE
refactor tests

### DIFF
--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 
 # first party
-from gypt_matplotlib import context_managers
+from gypt_matplotlib import constants, context_managers, utils
 
 # local
 from .utils import assert_identical_images
@@ -20,7 +20,7 @@ def test_auto_safe(out_png_path: Path):
 
 def test_au_plot(img_au_plot: Path, out_png_path: Path):
     with context_managers.au_plot(), context_managers.auto_save(out_png_path):
-        plt.title(r"plot with $\text{a.u.}$")
+        plt.title(f"plot with {utils.tex(constants.AU)}")
     assert img_au_plot != out_png_path, "Output and control are the same!"
 
     assert_identical_images(out_png_path, img_au_plot)


### PR DESCRIPTION
Use constants defined in the package instead of hard-coded strings.